### PR TITLE
Initial release of USB gadget mode

### DIFF
--- a/config/cmdline.txt
+++ b/config/cmdline.txt
@@ -1,1 +1,1 @@
-console=tty1 root=PARTUUID=738a4d67-02 rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait consoleblank=0
+console=tty1 root=PARTUUID=738a4d67-02 rootfstype=ext4 elevator=deadline fsck.repair=yes rootwait modules-load=dwc2,g_ether consoleblank=0

--- a/config/cmdline_goodtft.txt
+++ b/config/cmdline_goodtft.txt
@@ -1,0 +1,1 @@
+dwc_otg.lpm_enable=0 console=tty1 console=ttyAMA0,115200 root=/dev/mmcblk0p2 rootfstype=ext4 elevator=deadline rootwait modules-load=dwc2,g_ether fbcon=map:10 fbcon=font:ProFont6x11 logo.nologo

--- a/config/config-nomal.txt
+++ b/config/config-nomal.txt
@@ -1,0 +1,65 @@
+# For more options and information see
+# http://rpf.io/configtxt
+# Some settings may impact device functionality. See link above for details
+
+# uncomment if you get no picture on HDMI for a default "safe" mode
+#hdmi_safe=1
+
+# uncomment this if your display has a black border of unused pixels visible
+# and your display can output without overscan
+#disable_overscan=1
+
+# uncomment the following to adjust overscan. Use positive numbers if console
+# goes off screen, and negative if there is too much border
+#overscan_left=16
+#overscan_right=16
+#overscan_top=16
+#overscan_bottom=16
+
+# uncomment to force a console size. By default it will be display's size minus
+# overscan.
+#framebuffer_width=1280
+#framebuffer_height=720
+
+# uncomment if hdmi display is not detected and composite is being output
+#hdmi_force_hotplug=1
+
+# uncomment to force a specific HDMI mode (this will force VGA)
+#hdmi_group=1
+#hdmi_mode=1
+
+# uncomment to force a HDMI mode rather than DVI. This can make audio work in
+# DMT (computer monitor) modes
+#hdmi_drive=2
+
+# uncomment to increase signal to HDMI, if you have interference, blanking, or
+# no display
+#config_hdmi_boost=4
+
+# uncomment for composite PAL
+#sdtv_mode=2
+
+#uncomment to overclock the arm. 700 MHz is the default.
+#arm_freq=800
+
+# Uncomment some or all of these to enable the optional hardware interfaces
+#dtparam=i2c_arm=on
+#dtparam=i2s=on
+#dtparam=spi=on
+
+# Uncomment this to enable the lirc-rpi module
+#dtoverlay=lirc-rpi
+
+# Additional overlays and parameters are documented /boot/overlays/README
+
+# Enable audio (loads snd_bcm2835)
+dtparam=audio=on
+
+[pi4]
+# Enable DRM VC4 V3D driver on top of the dispmanx display stack
+#dtoverlay=vc4-fkms-v3d
+#max_framebuffers=2
+
+[all]
+#dtoverlay=vc4-fkms-v3d
+dtoverlay=dwc2

--- a/config/config-noobs-nomal.txt
+++ b/config/config-noobs-nomal.txt
@@ -1,0 +1,68 @@
+# For more options and information see
+# http://rpf.io/configtxt
+# Some settings may impact device functionality. See link above for details
+
+# uncomment if you get no picture on HDMI for a default "safe" mode
+#hdmi_safe=1
+
+# uncomment this if your display has a black border of unused pixels visible
+# and your display can output without overscan
+#disable_overscan=1
+
+# uncomment the following to adjust overscan. Use positive numbers if console
+# goes off screen, and negative if there is too much border
+#overscan_left=16
+#overscan_right=16
+#overscan_top=16
+#overscan_bottom=16
+
+# uncomment to force a console size. By default it will be display's size minus
+# overscan.
+#framebuffer_width=1280
+#framebuffer_height=720
+
+# uncomment if hdmi display is not detected and composite is being output
+#hdmi_force_hotplug=1
+
+# uncomment to force a specific HDMI mode (this will force VGA)
+#hdmi_group=1
+#hdmi_mode=1
+
+# uncomment to force a HDMI mode rather than DVI. This can make audio work in
+# DMT (computer monitor) modes
+#hdmi_drive=2
+
+# uncomment to increase signal to HDMI, if you have interference, blanking, or
+# no display
+#config_hdmi_boost=4
+
+# uncomment for composite PAL
+#sdtv_mode=2
+
+#uncomment to overclock the arm. 700 MHz is the default.
+#arm_freq=800
+
+# Uncomment some or all of these to enable the optional hardware interfaces
+#dtparam=i2c_arm=on
+#dtparam=i2s=on
+#dtparam=spi=on
+
+# Uncomment this to enable the lirc-rpi module
+#dtoverlay=lirc-rpi
+
+# Additional overlays and parameters are documented /boot/overlays/README
+
+# Enable audio (loads snd_bcm2835)
+dtparam=audio=on
+
+[pi4]
+# Enable DRM VC4 V3D driver on top of the dispmanx display stack
+#dtoverlay=vc4-fkms-v3d
+#max_framebuffers=2
+
+[all]
+#dtoverlay=vc4-fkms-v3d
+dtoverlay=dwc2
+
+# NOOBS Auto-generated Settings:
+hdmi_force_hotplug=1

--- a/config/config.txt
+++ b/config/config.txt
@@ -23,3 +23,4 @@ disable_overscan=1
 hdmi_group=0
 hdmi_drive=1
 hdmi_force_hotplug=1
+dtoverlay=dwc2

--- a/config/g_ether.conf
+++ b/config/g_ether.conf
@@ -1,0 +1,1 @@
+options g_ether host_addr=1e:81:5d:55:51:1d dev_addr=c6:65:6e:bc:7a:01

--- a/config/usb0
+++ b/config/usb0
@@ -4,4 +4,3 @@ iface usb0 inet static
         netmask 255.255.255.0
         network 192.168.7.0
         broadcast 192.168.7.255
-        gateway 192.168.7.1

--- a/config/usb0
+++ b/config/usb0
@@ -1,0 +1,7 @@
+allow-hotplug usb0
+iface usb0 inet static
+        address 192.168.7.2
+        netmask 255.255.255.0
+        network 192.168.7.0
+        broadcast 192.168.7.255
+        gateway 192.168.7.1

--- a/install.sh
+++ b/install.sh
@@ -138,6 +138,7 @@ cat ./config/hostname >/etc/hostname
 cat ./config/hosts >/etc/hosts
 
 cat ./config/usb0 >/etc/network/interfaces.d/usb0 # set static ip to usb0 interface
+cat ./config/g_ether.conf >/etc/modprobe.d/g_ether.conf # set static MAC address to usb0 interface
 
 echo " done"
 

--- a/install.sh
+++ b/install.sh
@@ -132,9 +132,12 @@ echo -n "Applying configurations..."
 
 cat ./config/config.txt >/boot/config.txt
 sed ' 1 s/.*/& consoleblank=0/' /boot/cmdline.txt
+touch /boot/ssh
 
 cat ./config/hostname >/etc/hostname
 cat ./config/hosts >/etc/hosts
+
+cat ./config/usb0 >/etc/network/interfaces.d/usb0 # set static ip to usb0 interface
 
 echo " done"
 
@@ -169,6 +172,12 @@ echo " done"
 echo -n "Setting permission for display drivers..."
 chmod +x /home/modbros/display-drivers/GoodTFT/*show
 chmod +x /home/modbros/display-drivers/Waveshare/*show
+echo " done"
+
+echo -n "Copy custom configs for GoodTFT..."
+cp -f ./config/config-nomal.txt /home/modbros/display-drivers/GoodTFT/boot/
+cp -f ./config/config-noobs-nomal.txt /home/modbros/display-drivers/GoodTFT/boot/
+cp -f ./config/cmdline_goodtft.txt /home/modbros/display-drivers/GoodTFT/usr/cmdline.txt
 echo " done"
 
 # ==========================================================================

--- a/scripts/apply_new_config.sh
+++ b/scripts/apply_new_config.sh
@@ -88,6 +88,12 @@ network_config() {
         sudo cp -f $WPA_CONFIG_CLEAN /etc/wpa_supplicant/wpa_supplicant.conf
         ;;
 
+    usb)
+        # connected by ethernet => set standard wpa config and we're done
+        log "configuration" "network mode: USB Ethernet - resetting wpa_supplicant"
+        sudo cp -f $WPA_CONFIG_CLEAN /etc/wpa_supplicant/wpa_supplicant.conf
+        ;;
+
     wifi)
         log "configuration" "network mode: Wifi - creating new wpa_supplicant"
         local ssid pw country wpa hidden

--- a/web/mobro/index.php
+++ b/web/mobro/index.php
@@ -73,6 +73,9 @@ include '../util.php';
 $eth = shell_exec('grep up /sys/class/net/*/operstate | grep eth0');
 $ethConnected = isset($eth) && trim($eth) !== '';
 
+$usb = shell_exec('grep up /sys/class/net/*/operstate | grep usb0');
+$ethConnected = isset($usb) && trim($usb) !== '';
+
 $ssid = shell_exec('iwgetid wlan0 -r');
 $wlanConnected = isset($ssid) && trim($ssid) !== '';
 

--- a/web/mobro/wizard.php
+++ b/web/mobro/wizard.php
@@ -185,6 +185,9 @@ include '../util.php';
 $eth = shell_exec('grep up /sys/class/net/*/operstate | grep eth0');
 $ethConnected = isset($eth) && trim($eth) !== '';
 
+$usb = shell_exec('grep up /sys/class/net/*/operstate | grep usb0');
+$ethConnected = isset($usb) && trim($usb) !== '';
+
 $ssid = shell_exec('iwgetid wlan0 -r');
 $wlanConnected = isset($ssid) && trim($ssid) !== '';
 


### PR DESCRIPTION
This PR should cover issue #1 

Main changes:
- added new NETWORK_MODE='usb'
- Raspberry is in USB gadget mode configured with static IP address 192.168.7.2
- UUID is now generated from Raspberry's `Serial` number instead of MAC address
- changed config files for USB gadget mode in GoodTFT drivers folder (not yet for Waveshare)
- updated install.sh script
- tested on Raspberry Pi Zero, Zero W and 4  (need to be done on other models)

Note: USB Gadget is compatible with Raspberry Pi 0, 0W, A, A+, and 4 only.  (Pi B, B+, 2, 3, 3A+, and 3B+ lack the required pin for OTG)